### PR TITLE
Add Go support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,44 @@ console.log(version);
 
 See [`deno/sqlite-vss/README.md`](./deno/README.md) for more details.
 
+### Go
+
+For Go developers, use the [Go](./go) module:
+
+```go
+package main
+
+import (
+	"fmt"
+	"log"
+
+	vss "github.com/asg017/sqlite-vss/go"
+)
+
+func main() {
+	// /usr/local/lib/sqlite/ext/sqlite-vss is where vss0 and vector0 are stored.
+	db, err := vss.Open("vss-example.db", "/usr/local/lib/sqlite/ext/sqlite-vss")
+	if err != nil {
+		log.Fatal()
+	}
+	defer db.Close()
+
+	r := db.QueryRow("select vss_version();")
+	if err := r.Err(); err != nil {
+		log.Fatal(err)
+	}
+
+	var versions any
+	if err := r.Scan(&versions); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(versions)
+}
+```
+
+See [`go/README.md`](./go/README.md) for more details.
+
 ### Datasette
 
 And for [Datasette](https://datasette.io/), install the [`datasette-sqlite-vss` plugin](https://datasette.io/plugins/datasette-sqlite-vss) with:

--- a/go/README.md
+++ b/go/README.md
@@ -1,0 +1,43 @@
+# sqlite-vss Go package
+
+
+This package wraps the [go-sqlite3](https://github.com/mattn/go-sqlite3) driver and automatically loads extensions when opening a database connection. 
+
+```go
+package main
+
+import (
+	"fmt"
+	"log"
+
+	vss "github.com/asg017/sqlite-vss/go"
+)
+
+func main() {
+	// /usr/local/lib/sqlite/ext/sqlite-vss is where vss0 and vector0 are stored.
+	db, err := vss.Open("vss-example.db", "/usr/local/lib/sqlite/ext/sqlite-vss")
+	if err != nil {
+		log.Fatal()
+	}
+	defer db.Close()
+
+	r := db.QueryRow("select vss_version();")
+	if err := r.Err(); err != nil {
+		log.Fatal(err)
+	}
+
+	var versions any
+	if err := r.Scan(&versions); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(versions)
+}
+```
+
+## Installing
+
+
+```bash
+go get github.com/asg017/sqlite-vss/go
+```

--- a/go/example/main.go
+++ b/go/example/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	vss "github.com/asg017/sqlite-vss/go"
+)
+
+func main() {
+	// /usr/local/lib/sqlite/ext/sqlite-vss is where vss0 and vector0 are stored.
+	db, err := vss.Open("vss-example.db", "/usr/local/lib/sqlite/ext/sqlite-vss")
+	if err != nil {
+		log.Fatal()
+	}
+	defer db.Close()
+
+	r := db.QueryRow("select vss_version();")
+	if err := r.Err(); err != nil {
+		log.Fatal(err)
+	}
+
+	var versions any
+	if err := r.Scan(&versions); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(versions)
+}

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,5 @@
+module github.com/asg017/sqlite-vss/go
+
+go 1.20
+
+require github.com/mattn/go-sqlite3 v1.14.16 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,0 +1,2 @@
+github.com/mattn/go-sqlite3 v1.14.16 h1:yOQRA0RpS5PFz/oikGwBEqvAWhWg5ufRz4ETLjwpU1Y=
+github.com/mattn/go-sqlite3 v1.14.16/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=

--- a/go/vss.go
+++ b/go/vss.go
@@ -1,0 +1,20 @@
+package vss
+
+import (
+	"database/sql"
+	"path"
+
+	"github.com/mattn/go-sqlite3"
+)
+
+// Open returns a sql.DB pre-configured with sqlite-vss extensions,
+// to work vss0 and vector0 files should be stored under extPath.
+func Open(dbName string, extPath string) (*sql.DB, error) {
+	sql.Register("sqlite-vss", &sqlite3.SQLiteDriver{
+		Extensions: []string{
+			path.Join(extPath, "vector0"),
+			path.Join(extPath, "vss0"),
+		},
+	})
+	return sql.Open("sqlite-vss", dbName)
+}


### PR DESCRIPTION
Hey, I've been playing around with sqlite-vss in Go quite a bit recently so thought I'd chuck up an MR.

It doesn't package up the extensions like the ts/py packages, it's just a lightweight wrapper around a Go driver to make things a little easier for Go folks to get up and running.