### PR TITLE
add metric type for vector comparison

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -95,7 +95,7 @@ The constructor of the `vss0` module takes in a list of column definitions. Curr
 
 An optional `factory=` option can be placed on individual columns. These are [Faiss factory strings](https://github.com/facebookresearch/faiss/wiki/The-index-factory) that give you more control over how the Faiss index is created. Consult the Faiss documentation to determine which factory makes the most sense for your use case. It's recommended that you include `IDMap2` to your factory string, in order to reconstruct vectors in queries. The default factory string is `"Flat,IDMap2"`, an exhaustive search index.
 
-There is also the `metrict_type=` option. These are [Faiss metric types](https://github.com/facebookresearch/faiss/wiki/MetricType-and-distances). The options are `L1`, `L2`, `INNER_PRODUCT`, `Linf`, `Canberra`, `BrayCurtis`, and `JensenShannon`. 
+There is also the `metrict_type=` option. These are [Faiss metric types](https://github.com/facebookresearch/faiss/wiki/MetricType-and-distances). The options are `L1`, `L2`, `INNER_PRODUCT`, `Linf`, `Canberra`, `BrayCurtis`, and `JensenShannon`. If you are planning on using the `JensenShannon` metric type, you must L1 normalize inputs as FAISS assumes the inputs are L1 normalized. You should also be aware that FAISS implements this as the JensenShannon divergence, not the JensenShannon distance. 
 
 By contention the table name should be prefixed with `vss_`. If your data exists in a "normal" table named `"xyz"`, then name the vss0 table `vss_xyz`.
 

--- a/docs.md
+++ b/docs.md
@@ -95,6 +95,8 @@ The constructor of the `vss0` module takes in a list of column definitions. Curr
 
 An optional `factory=` option can be placed on individual columns. These are [Faiss factory strings](https://github.com/facebookresearch/faiss/wiki/The-index-factory) that give you more control over how the Faiss index is created. Consult the Faiss documentation to determine which factory makes the most sense for your use case. It's recommended that you include `IDMap2` to your factory string, in order to reconstruct vectors in queries. The default factory string is `"Flat,IDMap2"`, an exhaustive search index.
 
+There is also the `metrict_type=` option. These are [Faiss metric types](https://github.com/facebookresearch/faiss/wiki/MetricType-and-distances). The options are `L1`, `L2`, `INNER_PRODUCT`, `Linf`, `Lp`, `Canberra`, `BrayCurtis`, and `JensenShannon`. 
+
 By contention the table name should be prefixed with `vss_`. If your data exists in a "normal" table named `"xyz"`, then name the vss0 table `vss_xyz`.
 
 #### Training

--- a/docs.md
+++ b/docs.md
@@ -95,7 +95,7 @@ The constructor of the `vss0` module takes in a list of column definitions. Curr
 
 An optional `factory=` option can be placed on individual columns. These are [Faiss factory strings](https://github.com/facebookresearch/faiss/wiki/The-index-factory) that give you more control over how the Faiss index is created. Consult the Faiss documentation to determine which factory makes the most sense for your use case. It's recommended that you include `IDMap2` to your factory string, in order to reconstruct vectors in queries. The default factory string is `"Flat,IDMap2"`, an exhaustive search index.
 
-There is also the `metrict_type=` option. These are [Faiss metric types](https://github.com/facebookresearch/faiss/wiki/MetricType-and-distances). The options are `L1`, `L2`, `INNER_PRODUCT`, `Linf`, `Lp`, `Canberra`, `BrayCurtis`, and `JensenShannon`. 
+There is also the `metrict_type=` option. These are [Faiss metric types](https://github.com/facebookresearch/faiss/wiki/MetricType-and-distances). The options are `L1`, `L2`, `INNER_PRODUCT`, `Linf`, `Canberra`, `BrayCurtis`, and `JensenShannon`. 
 
 By contention the table name should be prefixed with `vss_`. If your data exists in a "normal" table named `"xyz"`, then name the vss0 table `vss_xyz`.
 

--- a/src/sqlite-vss.cpp
+++ b/src/sqlite-vss.cpp
@@ -657,7 +657,7 @@ faiss::MetricType parse_metric_type(const std::string& metric_type) {
         {"L2", faiss::METRIC_L2},
         {"INNER_PRODUCT", faiss::METRIC_INNER_PRODUCT},
         {"Linf", faiss::METRIC_Linf},
-        {"Lp", faiss::METRIC_Lp},
+        // {"Lp", faiss::METRIC_Lp}, unavailable until metric arg is added
         {"Canberra", faiss::METRIC_Canberra},
         {"BrayCurtis", faiss::METRIC_BrayCurtis},
         {"JensenShannon", faiss::METRIC_JensenShannon}
@@ -713,8 +713,6 @@ unique_ptr<vector<VssIndexColumn>> parse_constructor(int argc,
             factory = string("Flat,IDMap2");
         }
 
-        // FIXME: should non-default factory be required to check for non-default metric type?
-        //        (seems like a yes to me but idk)
         faiss::MetricType metric_type;
         size_t metricStart, metricStringStartFrom;
 

--- a/src/sqlite-vss.cpp
+++ b/src/sqlite-vss.cpp
@@ -648,7 +648,28 @@ struct VssIndexColumn {
     string name;
     sqlite3_int64 dimensions;
     string factory;
+    faiss::MetricType metric;
 };
+
+faiss::MetricType parse_metric_type(const std::string& metric_type) {
+    static const std::unordered_map<std::string, faiss::MetricType> metric_type_map = {
+        {"L1", faiss::METRIC_L1},
+        {"L2", faiss::METRIC_L2},
+        {"INNER_PRODUCT", faiss::METRIC_INNER_PRODUCT},
+        {"Linf", faiss::METRIC_Linf},
+        {"Lp", faiss::METRIC_Lp},
+        {"Canberra", faiss::METRIC_Canberra},
+        {"BrayCurtis", faiss::METRIC_BrayCurtis},
+        {"JensenShannon", faiss::METRIC_JensenShannon}
+    };
+
+    auto it = metric_type_map.find(metric_type);
+    if (it == metric_type_map.end()) {
+        throw invalid_argument("unknown metric type: " + metric_type);
+    }
+
+    return it->second;
+}
 
 unique_ptr<vector<VssIndexColumn>> parse_constructor(int argc,
                                                      const char *const *argv) {
@@ -691,7 +712,34 @@ unique_ptr<vector<VssIndexColumn>> parse_constructor(int argc,
         } else {
             factory = string("Flat,IDMap2");
         }
-        columns->push_back(VssIndexColumn{name, dimensions, factory});
+
+        // FIXME: should non-default factory be required to check for non-default metric type?
+        //        (seems like a yes to me but idk)
+        faiss::MetricType metric_type;
+        size_t metricStart, metricStringStartFrom;
+
+        if ((metricStart = arg.find("metric_type", rparen)) != string::npos &&
+            (metricStringStartFrom = arg.find("=", metricStart)) != string::npos) {
+
+            size_t lquote = arg.find_first_not_of(" ", metricStringStartFrom + 1);
+            size_t rquote = arg.find(",", lquote);
+
+            if (rquote == string::npos) {
+                rquote = arg.size();
+            }
+
+            try {
+                metric_type = parse_metric_type(arg.substr(lquote, rquote - lquote));
+            } catch (const invalid_argument& e) {
+                throw;
+            }
+
+        } else {
+            // L2 is the default
+            metric_type = faiss::METRIC_L2; 
+        }
+
+        columns->push_back(VssIndexColumn{name, dimensions, factory, metric_type});
     }
 
     return columns;
@@ -712,7 +760,13 @@ static int init(sqlite3 *db,
     sqlite3_str_appendall(str,
                           "create table x(distance hidden, operation hidden");
 
-    auto columns = parse_constructor(argc, argv);
+    unique_ptr<vector<VssIndexColumn>> columns;
+    try {
+        columns = parse_constructor(argc, argv);
+    } catch (const invalid_argument& e) {
+        *pzErr = sqlite3_mprintf(e.what());
+        return SQLITE_ERROR;
+    }
 
     if (columns == nullptr) {
         *pzErr = sqlite3_mprintf("Error parsing constructor");
@@ -747,7 +801,7 @@ static int init(sqlite3 *db,
 
             try {
 
-                auto index = faiss::index_factory(iter->dimensions, iter->factory.c_str());
+                auto index = faiss::index_factory(iter->dimensions, iter->factory.c_str(), iter->metric);
                 pTable->indexes.push_back(new vss_index(index));
 
             } catch (faiss::FaissException &e) {


### PR DESCRIPTION
Decided to take a stab at #6. Tests passed and also tested some more in my own go project. Let me know if there is anything you'd like changed. 

I was wondering whether we want to skip checking for the metric type option if the factory option is not provided. As it is, it will still check without a factory option provided. I can tweak it not to though if that is preferred.  