### PR TITLE
Update license field following SPDX 2.1 license expression standard

### DIFF
--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -9,7 +9,7 @@ description = "FFI bindings to the sqlite-vss SQLite extension"
 homepage = "https://github.com/asg017/sqlite-vss"
 repository = "https://github.com/asg017/sqlite-vss"
 keywords = ["sqlite", "sqlite-extension"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 


### PR DESCRIPTION
The new recommendation is to follow the SPDX 2.1 standard. This allows automatic license verification software to work properly. Reference: https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields